### PR TITLE
Added adc for cds sensor

### DIFF
--- a/watch_app/src/ad_converter.py
+++ b/watch_app/src/ad_converter.py
@@ -26,6 +26,22 @@ class MCP3002:
         
         @exception ValueError  If channel is not 0 or 1
         """
+        """
+        MCP3002 SPI Communication Protocol Explanation
+
+        1. Command Format (8 bits):
+           Bit 7: Start bit (always 1)
+           Bit 6: Single/Diff (1=Single-ended, 0=Differential)
+           Bit 5: Channel select (0=CH0, 1=CH1)
+           Bit 4: MSBF (1=MSB first, 0=LSB first)
+           Bit 3-0: Don't care bits (dummy)
+
+        2. Response Format (16 bits total):
+           Byte 0: Bit 7-2: Don't care, Bit 1-0: Upper 2 bits of ADC result
+           Byte 1: Bit 7-0: Lower 8 bits of ADC result
+
+        Example breakdown:
+        """
         if channel not in [0, 1]:
             raise ValueError("Channel must be 0 or 1")
         
@@ -33,7 +49,7 @@ class MCP3002:
         # Start bit (1) + Single/Diff (1) + Channel (1) + MSBF (1) + 4 dummy bits
         command = 0x68 if channel == 0 else 0x78  # 0x68 = ch0, 0x78 = ch1
         
-        # Send/receive data via SPI (3 bytes)
+        # Send/receive data via SPI (2 bytes)
         response = self.spi.xfer2([command, 0x00])
         
         # Extract 10-bit value from received data

--- a/watch_app/src/ad_converter.py
+++ b/watch_app/src/ad_converter.py
@@ -34,11 +34,11 @@ class MCP3002:
         command = 0x68 if channel == 0 else 0x78  # 0x68 = ch0, 0x78 = ch1
         
         # Send/receive data via SPI (3 bytes)
-        response = self.spi.xfer2([command, 0x00, 0x00])
+        response = self.spi.xfer2([command, 0x00])
         
         # Extract 10-bit value from received data
         # Combine lower 2 bits of 2nd byte with upper 8 bits of 3rd byte
-        adc_value = ((response[1] & 0x03) << 8) | response[2]
+        adc_value = ((response[0] & 0x03) << 8) | response[1]
         
         return adc_value
     

--- a/watch_app/src/ad_converter.py
+++ b/watch_app/src/ad_converter.py
@@ -1,0 +1,95 @@
+import spidev
+import time
+
+class MCP3002:
+    def __init__(self, bus=0, device=0):
+        """
+        Initialize MCP3002 ADC converter
+        
+        @param  bus     SPI bus number (typically 0)
+        @param  device  Device number (CE0=0, CE1=1)
+        """
+        self.spi = spidev.SpiDev()
+        self.spi.open(bus, device)
+        
+        # Configure SPI settings
+        self.spi.max_speed_hz = 1000000  # 1MHz
+        self.spi.mode = 0  # SPI mode 0 (CPOL=0, CPHA=0)
+        
+    def read_channel(self, channel):
+        """
+        Read AD value from specified channel
+        
+        @param  channel  Channel number (0 or 1)
+        
+        @retval adc_value  10-bit AD conversion value (0-1023)
+        
+        @exception ValueError  If channel is not 0 or 1
+        """
+        if channel not in [0, 1]:
+            raise ValueError("Channel must be 0 or 1")
+        
+        # MCP3002 command format
+        # Start bit (1) + Single/Diff (1) + Channel (1) + MSBF (1) + 4 dummy bits
+        command = 0x68 if channel == 0 else 0x78  # 0x68 = ch0, 0x78 = ch1
+        
+        # Send/receive data via SPI (3 bytes)
+        response = self.spi.xfer2([command, 0x00, 0x00])
+        
+        # Extract 10-bit value from received data
+        # Combine lower 2 bits of 2nd byte with upper 8 bits of 3rd byte
+        adc_value = ((response[1] & 0x03) << 8) | response[2]
+        
+        return adc_value
+    
+    def read_voltage(self, channel, vref=3.3):
+        """
+        Read voltage value from specified channel
+        
+        @param  channel  Channel number (0 or 1)
+        @param  vref     Reference voltage (default: 3.3V)
+        
+        @retval voltage  Voltage value in volts
+        """
+        adc_value = self.read_channel(channel)
+        voltage = (adc_value * vref) / 1024.0
+        return voltage
+    
+    def close(self):
+        """
+        Close SPI connection
+        """
+        self.spi.close()
+
+def main():
+    """
+    Main function to test MCP3002 ADC converter
+    """
+    # Initialize MCP3002 (using CE0)
+    adc = MCP3002(bus=0, device=0)
+    
+    try:
+        print("MCP3002 ADC converter test started")
+        print("Press Ctrl+C to exit")
+        
+        while True:
+            # Read CDS sensor value from channel 0
+            cds_adc_value = adc.read_channel(0)
+            cds_voltage = adc.read_voltage(0)
+            
+            print(f"CDS Sensor - AD value: {cds_adc_value:4d}, Voltage: {cds_voltage:.3f}V")
+            
+            # If using channel 1 as well
+            # ch1_adc_value = adc.read_channel(1)
+            # ch1_voltage = adc.read_voltage(1)
+            # print(f"Channel 1 - AD value: {ch1_adc_value:4d}, Voltage: {ch1_voltage:.3f}V")
+            
+            time.sleep(0.5)
+            
+    except KeyboardInterrupt:
+        print("\nExiting...")
+    finally:
+        adc.close()
+
+if __name__ == "__main__":
+    main()

--- a/watch_app/src/get_light_sensor.py
+++ b/watch_app/src/get_light_sensor.py
@@ -48,21 +48,19 @@ class GL5528Sensor:
         ## @details
         Checks the digital input from the specified GPIO pin.
         
-        ## @retval 1 Room is bright.
-        ## @retval 0 Room is dark.
+        ## @retval 0: Brightness is low (sensor detects OFF light).
+        ## @retval 1: Brightness is high (sensor detects ON light).
         """
+            adc = MCP3002(bus=0, device=0)
         try:
-            # Read digital input from Cds sensor
-            if GPIO.input(self.gpio_pin) == GPIO.HIGH:
-                # print("Room is bright.")
+            # チャンネル0からCdsセンサの値を読み取り
+            cds_adc_value = adc.read_channel(0)
+            if cds_adc_value >= 601:
                 return 1
             else:
-                # print("Room is dark.")
                 return 0
-        except Exception as e:
-            print(f"Error reading from Cds sensor: {e}")
-            GPIO.cleanup()
-            raise
+        finally:
+            adc.close()
 
     def cleanup(self):
         """

--- a/watch_app/src/get_light_sensor.py
+++ b/watch_app/src/get_light_sensor.py
@@ -90,7 +90,7 @@ def main():
     
     try:
         while True:
-            sensor.read_brightness()
+            print(sensor.read_brightness())
             time.sleep(1)  # Check every second
     except KeyboardInterrupt:
         print("Terminating the program...")

--- a/watch_app/src/get_light_sensor.py
+++ b/watch_app/src/get_light_sensor.py
@@ -55,12 +55,11 @@ class GL5528Sensor:
         try:
             # チャンネル0からCdsセンサの値を読み取り
             cds_adc_value = adc.read_channel(0)
+            adc.close()
             if cds_adc_value >= 601:
                 return 1
             else:
                 return 0
-        finally:
-            adc.close()
 
     def cleanup(self):
         """

--- a/watch_app/src/get_light_sensor.py
+++ b/watch_app/src/get_light_sensor.py
@@ -55,11 +55,14 @@ class GL5528Sensor:
         try:
             # チャンネル0からCdsセンサの値を読み取り
             cds_adc_value = adc.read_channel(0)
-            adc.close()
             if cds_adc_value >= 601:
+                adc.close()
                 return 1
             else:
+                adc.close()
                 return 0
+        finally:
+            adc.close()
 
     def cleanup(self):
         """

--- a/watch_app/src/get_light_sensor.py
+++ b/watch_app/src/get_light_sensor.py
@@ -1,5 +1,6 @@
 import RPi.GPIO as GPIO
 import time
+from ad_converter import MCP3002
 
 class GL5528Sensor:
     """
@@ -51,7 +52,8 @@ class GL5528Sensor:
         ## @retval 0: Brightness is low (sensor detects OFF light).
         ## @retval 1: Brightness is high (sensor detects ON light).
         """
-            adc = MCP3002(bus=0, device=0)
+
+        adc = MCP3002(bus=0, device=0)
         try:
             # チャンネル0からCdsセンサの値を読み取り
             cds_adc_value = adc.read_channel(0)


### PR DESCRIPTION
## Cdsセルによる室内の明るさに応じたライト制御
RaspiWatchでは、Cdsセルによって室内の明るさを取得し、それに応じたライトの制御を可能にします。  
一定時間人感センサーが反応しない場合、RaspiWatchでは自動的にライトを消灯します。  
ADCがこれまでは実装されていなかったので、カーテンを閉めた状態で消灯しているか、しか判定することができませんでした。（とても暗い部屋以外は、すべてライトが点灯していると判定していました。）  
そのため、日中にカーテンを開けて自然光が入る状態で、ライトを消灯してもRaspiWatchはライトが点灯していると判定してしまい、一定時間経過後に自動的にライトの消灯操作を実施します。  
ライトの消灯操作が固有の信号であればよいのですが、私の家のライトは安物なので、ライトのON/OFF信号が同じです。つまり、このケースではRaspiWatchはライトを消灯しにいっているのに、実際には点灯してしまいます。  
これを解決するためにADCを使用することで、より細かい（0-1024までの数値で）粒度で、部屋の明るさを取得します。
これによって、以下の機能が実現できます。  
- カーテンを開けた状態かつ、ライト消灯で外出しても、RaspiWatchはライトが消灯されていることを把握できる。
ADCを採用していなければ、このケースで外出した場合、一定時間でライトのON/OFF信号が送信されることになります。（全てはライトのON/OFF信号が同じなことが悪いのです。。安物なので。。）
より具体的な仕様は以下になります。  
- 明るさが601以上の場合（とても明るい）、ライトが点灯していると判定する。
- 明るさが401以上、600以下の場合、ライトが消灯していると判定する。（カーテンを開けた状態で、自然光によって少し明るい程度）
- 明るさが400以下の場合、ライトが消灯していると判定する。（カーテンを閉めた状態でライトを消灯しているとても暗い部屋）  
参考程度に、動作確認で取得したCdsセルの明るさ値の目安は以下です。  
- カーテン開かつライト点灯：700以上
- カーテン開かつライト消灯：540程度
- カーテン閉かつライト消灯：60程度
- カーテン閉かつライト点灯：700以上
これにより、実際のライトの点灯状態と、RaspiWatchで持っているライトの点灯状態を一致させることができます。